### PR TITLE
feat: enable ReadyToRun and trim unused code

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,9 +20,9 @@ jobs:
     - name: Test
       run: dotnet test --no-build --verbosity normal
     - name: Publish for win-x64
-      run: dotnet publish -c Release -r win-x64 -p:PublishSingleFile=true --self-contained true
+      run: dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishTrimmed=True
     - name: Publish for win-arm64
-      run: dotnet publish -c Release -r win-arm64 -p:PublishSingleFile=true --self-contained true
+      run: dotnet publish -c Release -r win-arm64 --self-contained true -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishTrimmed=True
     - uses: actions/upload-artifact@v3
       with:
         name: release-win-x64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ steps:
     command: 'publish'
     publishWebProjects: false
     projects: 'EnergyStar/EnergyStar.csproj'
-    arguments: '-c ReleaseInvisible -r win-x64 -p:PublishSingleFile=true --self-contained true'
+    arguments: '-c ReleaseInvisible -r win-x64 --self-contained true -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishTrimmed=True'
     zipAfterPublish: false
     modifyOutputPath: false
 
@@ -33,7 +33,7 @@ steps:
     command: 'publish'
     publishWebProjects: false
     projects: 'EnergyStar/EnergyStar.csproj'
-    arguments: '-c ReleaseInvisible -r win-arm64 -p:PublishSingleFile=true --self-contained true'
+    arguments: '-c ReleaseInvisible -r win-arm64 --self-contained true -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishTrimmed=True'
     zipAfterPublish: false
     modifyOutputPath: false
 


### PR DESCRIPTION
- Reduce the size of the executable to approximately 14MB
- Enable ReadyToRun AOT compilation (which improves startup performance )