### PR TITLE
Use native AOT toolchain to reduce binary size

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v3
@@ -20,14 +20,14 @@ jobs:
     - name: Test
       run: dotnet test --no-build --verbosity normal
     - name: Publish for win-x64
-      run: dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishTrimmed=True
+      run: dotnet publish -c Release -r win-x64 --self-contained true
     - name: Publish for win-arm64
-      run: dotnet publish -c Release -r win-arm64 --self-contained true -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishTrimmed=True
+      run: dotnet publish -c Release -r win-arm64 --self-contained true
     - uses: actions/upload-artifact@v3
       with:
         name: release-win-x64
-        path: /home/runner/work/EnergyStar/EnergyStar/EnergyStar/bin/Release/net6.0/win-x64/publish/EnergyStar.exe
+        path: ${{ github.workspace }}/EnergyStar/bin/Release/net6.0/win-x64/publish/EnergyStar.exe
     - uses: actions/upload-artifact@v3
       with:
         name: release-win-arm64
-        path: /home/runner/work/EnergyStar/EnergyStar/EnergyStar/bin/Release/net6.0/win-arm64/publish/EnergyStar.exe
+        path: ${{ github.workspace }}/EnergyStar/bin/Release/net6.0/win-arm64/publish/EnergyStar.exe

--- a/EnergyStar/EnergyStar.csproj
+++ b/EnergyStar/EnergyStar.csproj
@@ -14,4 +14,8 @@
     <Folder Include="Config\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.ILCompiler; runtime.win-x64.Microsoft.DotNet.ILCompiler" Version="7.0.0-preview.6.22324.4" />
+  </ItemGroup>
+
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ steps:
     command: 'publish'
     publishWebProjects: false
     projects: 'EnergyStar/EnergyStar.csproj'
-    arguments: '-c ReleaseInvisible -r win-x64 --self-contained true -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishTrimmed=True'
+    arguments: '-c ReleaseInvisible -r win-x64 --self-contained true'
     zipAfterPublish: false
     modifyOutputPath: false
 
@@ -33,7 +33,7 @@ steps:
     command: 'publish'
     publishWebProjects: false
     projects: 'EnergyStar/EnergyStar.csproj'
-    arguments: '-c ReleaseInvisible -r win-arm64 --self-contained true -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishTrimmed=True'
+    arguments: '-c ReleaseInvisible -r win-arm64 --self-contained true'
     zipAfterPublish: false
     modifyOutputPath: false
 


### PR DESCRIPTION
Replace ReadToRun with [native AOT compiler](https://www.nuget.org/packages/Microsoft.DotNet.ILCompiler/) to reduce binary size.

|            |Before  |After  |Smaller |
-------------|--------|-------|--------|
Binary Size  |14.4 MB |4.2 MB |70%     |
Memory Usage |4.0 MB  |1.4 MB |65%     |

Tested on both GitHub Actions and Azure Pipelines.

Works with `features/config` branch where `System.Text.Json` is used, which uses reflection.

Build requirements:

- Windows SDK
- Microsoft.VisualStudio.Component.VC.Tools.x86.x64
- Microsoft.VisualStudio.Component.VC.Tools.ARM64

Build commands:

```
dotnet publish -c Release -r win-x64 --self-contained true
dotnet publish -c Release -r win-arm64 --self-contained true
```